### PR TITLE
add a contributing file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing Guidelines
+
+Contributions to HCA working group repos are subject to overall HCA
+governance and technical guidance. In addition, contributors are
+expected to abide by the following guidelines:
+
+1. Rough consensus and running code: instead of formal procedures for
+   agreeing on everything, systems with working prototypes and existing
+   users are prioritized as platforms for discussion.
+
+1. Keep it simple: prioritize scalability and the ability to keep the
+   project easy to understand and scale over features. Use
+   well-supported upstream solutions where possible. Provide useful
+   defaults and don't expose unnecessary configuration options.
+
+1. Separation of concerns and layers: code should be modular and
+   encapsulate functionality, providing a well-defined interface
+   that hides complexity from the end user.
+
+1. Don't break the build: pull requests are expected to pass all
+   automated CI checks.
+
+1. Keep the build simple: Automated CI checks that are fragile or don't
+   serve a clear agreed upon purpose will be removed.
+
+1. All code review comments must be addressed, even if a pull request 
+   has already been merged.
+
+1. All code must be reviewed by at least 1 other team member.
+
+1. All pull requests relating to an issue must include the text
+   "fixes \#123" or "closes \#123", where \#123 is the issue number.
+
+1. Individual commit messages should clearly express the commit's purpose.


### PR DESCRIPTION
This is a draft CONTRIBUTING.md file for all projects in the Cell Atlas Github organization. This is based off of the CONTRIBUTING.md file in the [data-store](https://github.com/HumanCellAtlas/data-store) repository.