### PR TITLE
add issue and pull request templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!-- 
+**IF YOU ARE FILING A BUG**, please uncomment/use the markdown below
+and apply the 'bug' label.
+-->
+
+<!--
+## Software version (git hash, date, branch)
+## Expected behavior
+## Actual behavior
+## Steps to reproduce the behavior
+-->
+
+<!--
+**IF YOU ARE FILING A FEATURE REQUEST**, please uncomment/use the markdown below
+-->
+
+<!--
+
+## User story
+
+* As a <type of user>
+* I want to <action>
+* so that <result>
+
+## Definition of done
+
+-->
+
+<!--
+
+Other best practices:
+
+* Use the GitHub keywords "fixed by" or "closed by" if your issue is completely resolved
+  by a PR: "Fixed by #123" or "Closed by #456"
+* If you are on the core dev team for this repo, mention your issue in daily
+  scrum, sprint review, or to the PM.
+* Also, assign the issue to someone or to yourself.
+
+-->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Please make sure to provide a meaningful title for your PR. 
+Do not keep the default title.
+-->
+
+<!--
+Use GitHub keywords "fixes" or "closes" followed by an issue number if your PR
+completely resolves an issue:
+"Fixes #123" or "Closes #456"
+-->
+
+<!-- 
+Describe how you tested this PR, and how you will test the feature after it is
+merged. Uncomment below:
+
+### Test plan
+-->
+
+<!--
+Describe any special instructions to the operator who will deploy your code to
+the integration, staging and production deployments. Uncomment below:
+
+### Deployment instructions & migrations
+-->
+
+<!-- 
+Add notes to highlight the feature when it's released/demoed. Uncomment the
+headings below:
+
+### Release notes
+-->
+
+<!--
+Do you want your PR to be merged by the reviewer using squash or rebase
+merging? If so, mention it here.
+-->


### PR DESCRIPTION
These are draft issue/pull request templates for all projects in the Cell Atlas Github organization. This is based off of the issue and pull request templates in the [data-store](https://github.com/HumanCellAtlas/data-store) repository.